### PR TITLE
Update from #call to #fetch for memoization call

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,12 @@ AllCops:
   TargetRubyVersion: 2.7
   NewCops: enable
 
+Layout/LineLength:
+  Max: 120
+
+Metrics/BlockLength:
+  AllowedMethods: ["describe"]
+
 Style/AccessModifierDeclarations:
   Enabled: true
   EnforcedStyle: inline
@@ -17,6 +23,3 @@ Style/StringLiterals:
 Style/StringLiteralsInInterpolation:
   Enabled: true
   EnforcedStyle: double_quotes
-
-Layout/LineLength:
-  Max: 120

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+## [0.2.0] - 2024-02-14
+
+- **BREAKING**: Changes `MemoPad::Memo#call` to `MemoPad::Memo#fetch` to more closely match interfaces like `ActiveSupport::Cache`.
+- Add `#read` and `#write` methods to allow for lower-level manipulation of the cached values, similarly inspired by the interface of `ActiveSupport::Cache`.
+
 ## [0.1.0] - 2024-01-22
 
 - Initial release

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    memo_pad (0.1.0)
+    memo_pad (0.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If bundler is not being used to manage dependencies, install the gem by executin
 ## Usage
 
 1. First, `include MemoPad` in your class.
-2. Then use `memo_pad.call(name, *args) do; end` to memoize the result of the block.
+2. Then use `memo_pad.fetch(name, *args) do; end` to memoize the result of the block.
 3. There is no step 3.
 
 ```ruby
@@ -35,30 +35,41 @@ class Foo
   include MemoPad
 
   def expensive_method
-    memo_pad.call(:expensive_method) do
+    memo_pad.fetch(:expensive_method) do
       # Do some expensive work here
     end
   end
 
   def expensive_method_with_arguments(foo, bar: nil)
-    memo_pad.call(:expensive_method, foo, bar) do
+    memo_pad.fetch(:expensive_method, foo, bar) do
       # Do expensive work here, respecting the values of `foo` and `bar`
     end
   end
 
   def complex_memoization
-    first_part = memo_pad.call(:complex_memoization_first) do
+    first_part = memo_pad.fetch(:complex_memoization_first) do
       # Some independent expensive work
     end
 
     # Maybe some other unmemoized work
 
-    memo_pad.call(:complex_memoization_second, first_part) do
+    memo_pad.fetch(:complex_memoization_second, first_part) do
       # Some other expensive work, respecting the value of `first_part`
     end
   end
 end
 ```
+
+You can directly write a memo, if needed, with `#write`. It has nearly the same signature as `#fetch`, the name and optional list of arguments, with the addition of the `value:` keyword argument to supply the value to write to the memo.
+
+```ruby
+def precache_things(things)
+  things.each do |thing|
+    memo_pad.write(:has_thing?, thing, value: true)
+  end
+end
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/memo_pad.rb
+++ b/lib/memo_pad.rb
@@ -12,7 +12,7 @@ require_relative "memo_pad/memo"
 # Memoize results of complex executions on its memo_pad:
 #
 #   def expensive_method
-#     memo_pad.call(:expensive_method) do
+#     memo_pad.fetch(:expensive_method) do
 #       # perform the expensive work
 #     end
 #   end
@@ -20,7 +20,7 @@ require_relative "memo_pad/memo"
 # Pass in any arguments that the memoized result would depend on, if any:
 #
 #   def expensive_with_arguments(foo, bar: nil)
-#     memo_pad.call(:expensive_with_arguments, foo, bar) do
+#     memo_pad.fetch(:expensive_with_arguments, foo, bar) do
 #       # perform the expensive work
 #     end
 #   end

--- a/lib/memo_pad/memo.rb
+++ b/lib/memo_pad/memo.rb
@@ -11,9 +11,22 @@ module MemoPad
       end
     end
 
-    def call(method_name, *args, &block)
-      result = cache[method_name].fetch(args, &block)
-      cache[method_name][args] = result
+    def fetch(method_name, *args, &block)
+      read!(method_name, *args)
+    rescue KeyError
+      write(method_name, *args, value: block.call)
+    end
+
+    def read(method_name, *args)
+      cache[method_name].fetch(args, nil)
+    end
+
+    def read!(method_name, *args)
+      cache[method_name].fetch(args)
+    end
+
+    def write(method_name, *args, value:)
+      cache[method_name][args] = value
     end
   end
 end

--- a/lib/memo_pad/version.rb
+++ b/lib/memo_pad/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MemoPad
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
- Also add `#read` and `#write` for lower-level access to the memo.
- Inspired by `ActiveSupport::Cache` interface.
