### PR TITLE
Also include memo_pad class method

### DIFF
--- a/lib/memo_pad.rb
+++ b/lib/memo_pad.rb
@@ -25,7 +25,11 @@ require_relative "memo_pad/memo"
 #     end
 #   end
 module MemoPad
-  class Error < StandardError; end
+  def self.included(klass)
+    def klass.memo_pad
+      @@memo_pad ||= MemoPad::Memo.new
+    end
+  end
 
   def memo_pad
     @memo_pad ||= MemoPad::Memo.new

--- a/lib/memo_pad.rb
+++ b/lib/memo_pad.rb
@@ -27,7 +27,7 @@ require_relative "memo_pad/memo"
 module MemoPad
   def self.included(klass)
     def klass.memo_pad
-      @@memo_pad ||= MemoPad::Memo.new
+      @memo_pad ||= MemoPad::Memo.new
     end
   end
 


### PR DESCRIPTION
Class methods need to be memoized from time to time, too.

- Add `.memo_pad` when including the module.
- This is separate from the per-instance memo pads, with its own state.
- Remove the unused `Error` class that got added automatically by Bundler during setup which errantly adds a `Foo::Error` to _every_ class that gets `MemoPad` included into it.
- Update all rest `call_tracker` calls to use the attribute methods instead of variables.
